### PR TITLE
Jwt token provider added

### DIFF
--- a/userservice/src/main/java/com/example/userservice/security/JwtTokenProvider.java
+++ b/userservice/src/main/java/com/example/userservice/security/JwtTokenProvider.java
@@ -1,0 +1,78 @@
+package com.example.userservice.security;
+
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private String jwtSecret;
+
+    @Value("${jwt.expiration}")
+    private long jwtExpiration;
+
+    private SecretKey key;
+
+    @PostConstruct
+    public void init(){
+        key= Keys.hmacShaKeyFor(jwtSecret.getBytes());
+    }
+
+    public String generateToken(String email){
+        Date now = new Date();
+
+        Date expiry= new Date(now.getTime()+ jwtExpiration);
+
+        return Jwts.builder()
+                .subject(email)
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(key)
+                .compact();
+    }
+
+    public String getEmailFromToken(String jwtToken){
+        Claims claims= Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(jwtToken)
+                .getPayload();
+
+        return claims.getSubject();
+    }
+
+    public boolean validateJwt(String jwtToken){
+        try {
+            Jwts.parser()
+                    .verifyWith(key)
+                    .build()
+                    .parseSignedClaims(jwtToken);
+            return true;
+
+        } catch (ExpiredJwtException ex) {
+            log.error("JWT expired {}", ex.getMessage());
+        } catch (MalformedJwtException ex) {
+            log.error("Invalid JWT {}", ex.getMessage());
+        } catch (UnsupportedJwtException ex) {
+            log.error("Unsupported JWT {}", ex.getMessage());
+        } catch (IllegalArgumentException ex) {
+            log.error("JWT claims empty {}", ex.getMessage());
+        } catch (Exception ex){
+            log.error("Runtime Exception {}", ex.getMessage());
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
This PR adds the `JwtTokenProvider` class to manage JWT operations in the user service. It generates signed tokens using the user's email as the subject, including issued and expiration timestamps, with the signing key initialized from application configuration.

The class also provides methods to extract the email from a token and validate JWTs by verifying their signature and structure, with logging for common exceptions such as expired, malformed, and unsupported tokens.
